### PR TITLE
Reload order meta in process_transaction to avoid conflicts

### DIFF
--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -496,6 +496,9 @@ class Swedbank_Pay_Api {
 	 */
 	public function process_transaction( WC_Order $order, array $transaction ) {
 		$transaction_id = $transaction['number'];
+		
+		// Reload order meta to ensure we have the latest changes and avoid conflicts from parallel scripts
+		$order->read_meta_data();
 
 		// Don't update order status if transaction ID was applied before
 		$transactions = $order->get_meta( '_swedbank_pay_transactions' );


### PR DESCRIPTION
- The issue is caused by a race condition where the order is being modified by two processes at the same time.
- The thank-you page updates the order to completed, but the webhook arrives too soon and does not see this change.
- The webhook incorrectly updates the order back from "completed" to "processing".
- There is a safeguard in the plugin, but it fails because it loads outdated order data.