### PR TITLE
Adding filter for turning off background task dispatchment at shutdown hook

### DIFF
--- a/includes/class-swedbank-pay-api.php
+++ b/includes/class-swedbank-pay-api.php
@@ -437,7 +437,7 @@ class Swedbank_Pay_Api {
 		}
 
 		$result = $this->request( 'GET', $payment_order_id . '/financialtransactions' );
-		$transactions_list = $result['financialTransactions']['financialTransactionsList'];
+		$transactions_list = $result['financialTransactions']['financialTransactionsList'] ?? [];
 		// @todo Sort by "created" field using array_multisort
 		foreach ( $transactions_list as $transaction ) {
 			if ( $transaction_number === $transaction['number'] ) {

--- a/includes/class-swedbank-pay-background-queue.php
+++ b/includes/class-swedbank-pay-background-queue.php
@@ -270,8 +270,13 @@ class Swedbank_Pay_Background_Queue extends WC_Background_Process {
 	 * Save and run queue.
 	 */
 	public function dispatch_queue() {
-		if ( ! empty( $this->data ) ) {
-			$this->save()->dispatch();
-		}
+        if ( ! empty( $this->data ) ) {
+            $this->save();
+            if (apply_filters('swedbank_pay_dispatch_queue_at_shutdown', true, $this)) {
+                $this->dispatch();
+            } else {
+                $this->schedule_event();
+            }
+        }
 	}
 }


### PR DESCRIPTION
To further insure orders are not being modified by two processes at the same time I added this filter to able to turn of dispatchment of background tasks at the _shutdown_ hook. Instead the task will be executed by wp cron.
