### PR TITLE
Version 4.4.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 4.4.1
+* Fix           - Fixed an issue where automatic capture was sometimes used even when disabled in the plugin settings.
+* Fix           - Corrected the Trustly label on the settings page.
+* Tweak         - Added the 'Payee Reference' field to the admin order metabox.
+
 Version 4.4.0
 * Feature       - Added support for splitting the payment methods from Swedbank Pay into separate payment methods in WooCommerce. Currently only supported for the redirect flow.
 * Fix           - The selected language setting is now also used for the 'Seamless Menu' checkout flow.

--- a/includes/class-swedbank-pay-instant-capture.php
+++ b/includes/class-swedbank-pay-instant-capture.php
@@ -63,7 +63,12 @@ class Swedbank_Pay_Instant_Capture {
 		}
 
 		// Disable this feature if "Autocomplete" is active.
-		if ( 'yes' === $this->gateway->autocomplete ) {
+		if ( wc_string_to_bool( $this->gateway->autocomplete ) ) {
+			return;
+		}
+
+		$instant_capture = $this->gateway->instant_capture;
+		if ( empty( $instant_capture ) ) {
 			return;
 		}
 
@@ -81,7 +86,7 @@ class Swedbank_Pay_Instant_Capture {
 			try {
 				$this->instant_capture( $order );
 			} catch ( \Exception $e ) {
-				$context['error'] = sprintf( '%s: Warning: %s', __METHOD__, $e->getMessage() );
+				$context['error'] = \sprintf( '%s: Warning: %s', __METHOD__, $e->getMessage() );
 				Swedbank_Pay()->logger()->error( "[INSTANT CAPTURE]: Failed to capture order #{$order->get_order_number()}. Error: {$e->getMessage()}", $context );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 5.3
 Tested up to: 6.9
 Requires PHP: 7.4
 WC requires at least: 5.5.1
-WC tested up to: 10.6.1
-Stable tag: 4.4.0
+WC tested up to: 10.7.0
+Stable tag: 4.4.1
 License: Apache License 2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0
 
@@ -95,6 +95,11 @@ You are now done with configuring our plugin.
 Please update to version 1.2.0.
 
 == Changelog ==
+= 2026.04.27    - version 4.4.1 =
+* Fix           - Fixed an issue where automatic capture was sometimes used even when disabled in the plugin settings.
+* Fix           - Corrected the Trustly label on the settings page.
+* Tweak         - Added the 'Payee Reference' field to the admin order metabox.
+
 = 2026.03.23    - version 4.4.0 =
 * Feature       - Added support for splitting the payment methods from Swedbank Pay into separate payment methods in WooCommerce. Currently only supported for the redirect flow.
 * Fix           - The selected language setting is now also used for the 'Seamless Menu' checkout flow.

--- a/src/Utility/InstrumentsUtility.php
+++ b/src/Utility/InstrumentsUtility.php
@@ -46,7 +46,7 @@ class InstrumentsUtility {
 			),
 			'trustly'                          => array(
 				'instrument' => 'Trustly',
-				'name'       => __( 'Pay by bank', 'swedbank-pay-payment-menu' ),
+				'name'       => __( 'Trustly (Bank transfer)', 'swedbank-pay-payment-menu' ),
 			),
 			'mobile_pay'                       => array(
 				'instrument' => 'MobilePay',
@@ -125,5 +125,4 @@ class InstrumentsUtility {
 
 		return self::get_instruments()[ $instrument ]['instrument'] ?? null;
 	}
-
 }

--- a/swedbank-pay-payment-menu.php
+++ b/swedbank-pay-payment-menu.php
@@ -7,12 +7,12 @@
  * Author URI: https://profiles.wordpress.org/swedbankpay/
  * License: Apache License 2.0
  * License URI: http://www.apache.org/licenses/LICENSE-2.0
- * Version: 4.4.0
+ * Version: 4.4.1
  * Text Domain: swedbank-pay-payment-menu
  * Domain Path: /languages
  *
  * WC requires at least: 5.5.1
- * WC tested up to: 10.6.1
+ * WC tested up to: 10.7.0
  * Requires Plugins: woocommerce
  *
  * @package SwedbankPay
@@ -27,7 +27,7 @@ use KrokedilSwedbankPayDeps\Krokedil\Support\SystemReport;
 
 
 defined( 'ABSPATH' ) || exit;
-define( 'SWEDBANK_PAY_VERSION', '4.4.0' );
+define( 'SWEDBANK_PAY_VERSION', '4.4.1' );
 define( 'SWEDBANK_PAY_MAIN_FILE', __FILE__ );
 define( 'SWEDBANK_PAY_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SWEDBANK_PAY_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/templates/admin/payment-actions.php
+++ b/templates/admin/payment-actions.php
@@ -26,6 +26,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			: </strong> <?php echo esc_html( $info['paid']['transactionType'] ); ?>
 		<br/>
 	<?php endif; ?>
+		<?php if ( isset( $info['paid']['payeeReference'] ) ) : ?>
+		<strong><?php esc_html_e( 'Payee Reference', 'swedbank-pay-payment-menu' ); ?>
+			: </strong> <?php echo esc_html( $info['paid']['payeeReference'] ); ?>
+		<br/>
+	<?php endif; ?>
 	<?php if ( $gateway->api->can_capture( $order ) ) : ?>
 		<button id="swedbank_pay_capture"
 				data-nonce="<?php echo esc_attr( wp_create_nonce( 'swedbank_pay' ) ); ?>"

--- a/templates/admin/payment-actions.php
+++ b/templates/admin/payment-actions.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			: </strong> <?php echo esc_html( $info['paid']['transactionType'] ); ?>
 		<br/>
 	<?php endif; ?>
-		<?php if ( isset( $info['paid']['payeeReference'] ) ) : ?>
+	<?php if ( isset( $info['paid']['payeeReference'] ) ) : ?>
 		<strong><?php esc_html_e( 'Payee Reference', 'swedbank-pay-payment-menu' ); ?>
 			: </strong> <?php echo esc_html( $info['paid']['payeeReference'] ); ?>
 		<br/>


### PR DESCRIPTION
* Fix - Fixed an issue where automatic capture was sometimes used even when disabled in the plugin settings.
* Fix - Corrected the Trustly label on the settings page.
* Tweak - Added the 'Payee Reference' field to the admin order metabox.